### PR TITLE
add declare_namespace() to __init__.py

### DIFF
--- a/src/biograpy/__init__.py
+++ b/src/biograpy/__init__.py
@@ -1,2 +1,4 @@
 from drawer import Panel
 from seqrecord import SeqRecordDrawer, SliceSeqRec
+
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Hi,
Thanks for BioGraPy.

I couldn't install it using `pip`:

```bash
pip install git+https://github.com/apierleoni/BioGraPy.git 
```

```
Collecting git+https://github.com/apierleoni/BioGraPy.git
  Cloning https://github.com/apierleoni/BioGraPy.git to /tmp/pip-SpyCf4-build
    Complete output from command python setup.py egg_info:
    /usr/lib/python2.7/dist-packages/setuptools/dist.py:282: UserWarning: Normalizing '1.0b' to '1.0b0'
      normalized_version,
    running egg_info
    creating pip-egg-info/biograpy.egg-info
    writing requirements to pip-egg-info/biograpy.egg-info/requires.txt
    writing pip-egg-info/biograpy.egg-info/PKG-INFO
    writing namespace_packages to pip-egg-info/biograpy.egg-info/namespace_packages.txt
    writing top-level names to pip-egg-info/biograpy.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/biograpy.egg-info/dependency_links.txt
    writing entry points to pip-egg-info/biograpy.egg-info/entry_points.txt
    writing manifest file 'pip-egg-info/biograpy.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found
    
    error: Namespace package problem: biograpy is a namespace package, but its
    __init__.py does not call declare_namespace()! Please fix it.
    (See the setuptools manual under "Namespace Packages" for details.)
    "
```

but with this commit installation is now fixed.